### PR TITLE
fix(toolbox): ignore auto resizer if not mounted

### DIFF
--- a/.changeset/honest-buttons-learn.md
+++ b/.changeset/honest-buttons-learn.md
@@ -1,0 +1,5 @@
+---
+"@triozer/framer-toolbox": patch
+---
+
+Ignore auto resize hooks if the plugin is not mounted

--- a/packages/toolbox/src/components/framer-plugin.tsx
+++ b/packages/toolbox/src/components/framer-plugin.tsx
@@ -141,8 +141,8 @@ const FramerPlugin = React.forwardRef<HTMLDivElement, FramerPluginProps>(
     }, [mergedProps.showOnMounted])
 
     useEffect(() => {
-      plugin.showUI({ resizable: mergedProps.uiOptions.resizable })
-    }, [mergedProps.uiOptions.resizable])
+      plugin.setUIOptions(mergedProps.uiOptions)
+    }, [mergedProps.uiOptions])
 
     return (
       <main

--- a/packages/toolbox/src/components/framer-plugin.tsx
+++ b/packages/toolbox/src/components/framer-plugin.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useImperativeHandle, useRef, useState } from 'react'
 import type { UIOptions } from 'framer-plugin'
 import cx from 'classnames'
 

--- a/packages/toolbox/src/components/framer-plugin.tsx
+++ b/packages/toolbox/src/components/framer-plugin.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import type { UIOptions } from 'framer-plugin'
 import cx from 'classnames'
 
@@ -117,7 +117,14 @@ const FramerPlugin = React.forwardRef<HTMLDivElement, FramerPluginProps>(
       plugin,
     ])
 
-    const { ref: mainRef } = useAutoSizer(
+    const mainRef = useRef<HTMLDivElement>(null)
+
+    useImperativeHandle(ref, () => {
+      return mainRef.current!
+    }, [])
+
+    useAutoSizer(
+      mainRef,
       {
         enabled: mergedProps.autoResize!,
         options: {
@@ -131,22 +138,25 @@ const FramerPlugin = React.forwardRef<HTMLDivElement, FramerPluginProps>(
     )
 
     useEffect(() => {
-      if (mergedProps.autoResize && mergedProps.uiOptions.resizable)
+      if (!mergedProps.showOnMounted || hasMountedOnce.current) {
         return
-
-      if (mergedProps.showOnMounted && !hasMountedOnce.current) {
-        plugin.showUI(mergedProps.uiOptions)
-        hasMountedOnce.current = true
       }
+
+      plugin.showUI(mergedProps.uiOptions)
+      hasMountedOnce.current = true
     }, [mergedProps.showOnMounted])
 
     useEffect(() => {
-      plugin.setUIOptions(mergedProps.uiOptions)
-    }, [mergedProps.uiOptions])
+      if (!mainRef.current) {
+        return
+      }
+
+      plugin.showUI({ resizable: mergedProps.uiOptions.resizable })
+    }, [mergedProps.uiOptions.resizable])
 
     return (
       <main
-        ref={mergedProps.autoResize ? mainRef : ref}
+        ref={mainRef}
         {...props}
         className={cx(classes.framerPlugin, props.className)}
       >

--- a/packages/toolbox/src/hooks/auto-sizer.ts
+++ b/packages/toolbox/src/hooks/auto-sizer.ts
@@ -61,8 +61,6 @@ export interface AutoSizerOptions {
  * @public
  */
 export interface AutoSizerReturn {
-  /** The reference of the element to resize. */
-  ref: React.MutableRefObject<HTMLDivElement | null>
   /**
    * The dimensions of the plugin.
    *
@@ -78,16 +76,14 @@ export interface AutoSizerReturn {
  *
  * @example
  * ```tsx
- * const { ref, pluginDimensions, updatePluginDimensions } = useAutoSizer({ enabled: true, options: { resizable: true, width: 300, height: 400 } })
+ * const { pluginDimensions, updatePluginDimensions } = useAutoSizer(ref, { enabled: true, options: { resizable: true, width: 300, height: 400 } })
  * ```
  *
  * @public
  * @kind hook
  */
-export function useAutoSizer({ enabled, options }: AutoSizerOptions): AutoSizerReturn {
+export function useAutoSizer(ref: React.RefObject<HTMLDivElement | null>, { enabled, options }: AutoSizerOptions): AutoSizerReturn {
   const plugin = useFramerPlugin()
-
-  const ref = useRef<HTMLDivElement>(null)
 
   const haveBeenResized = useRef(false)
   const isCurrentlyResizing = useRef(false)
@@ -234,5 +230,5 @@ export function useAutoSizer({ enabled, options }: AutoSizerOptions): AutoSizerR
     }
   }, [ref, enabled, options.resizable])
 
-  return { ref, pluginDimensions, updatePluginDimensions }
+  return { pluginDimensions, updatePluginDimensions }
 }

--- a/packages/toolbox/src/hooks/auto-sizer.ts
+++ b/packages/toolbox/src/hooks/auto-sizer.ts
@@ -203,9 +203,11 @@ export function useAutoSizer({ enabled, options }: AutoSizerOptions): AutoSizerR
   }, 100)
 
   useLayoutEffect(() => {
+    if (!ref.current)
+      return
     if (!enabled)
       updatePluginDimensions('manual', options)
-  }, [enabled])
+  }, [ref, enabled])
 
   useLayoutEffect(() => {
     if (!enabled)

--- a/packages/toolbox/src/providers/framer-plugin.tsx
+++ b/packages/toolbox/src/providers/framer-plugin.tsx
@@ -1,5 +1,5 @@
 import { type UIOptions, framer } from 'framer-plugin'
-import { createContext, useEffect, useState } from 'react'
+import { createContext, useEffect, useRef, useState } from 'react'
 
 /**
  * The options of the UI interface.
@@ -15,6 +15,8 @@ export interface FramerPluginContextType {
   isLoaded: boolean
   /** The function to show the UI interface. */
   showUI: (options: UIOptions) => Promise<void>
+  /** The function to set the UI options. */
+  setUIOptions: (options: UIOptions) => void
 }
 
 /**
@@ -46,6 +48,8 @@ export const FramerPluginProvider: React.FC<{
   const [id, setId] = useState<string>()
   const [name, setName] = useState<string>()
 
+  const uiOptions = useRef<UIOptions>({})
+
   useEffect(() => {
     (async () => {
       const config = await fetch('/framer.json').then(res => res.json())
@@ -57,15 +61,20 @@ export const FramerPluginProvider: React.FC<{
     })()
   }, [])
 
-  const showUI = async (options: UIOptions) => {
+  const showUI = async (options?: UIOptions) => {
     await framer.showUI({
       title: name,
+      ...uiOptions.current,
       ...options,
     })
   }
 
+  const setUIOptions = (options: UIOptions) => {
+    uiOptions.current = options
+  }
+
   return (
-    <FramerPluginContext.Provider value={{ id: id!, name: name!, isLoaded, showUI }}>
+    <FramerPluginContext.Provider value={{ id: id!, name: name!, isLoaded, showUI, setUIOptions }}>
       {isLoaded && children}
     </FramerPluginContext.Provider>
   )

--- a/packages/toolbox/src/providers/framer-plugin.tsx
+++ b/packages/toolbox/src/providers/framer-plugin.tsx
@@ -15,8 +15,6 @@ export interface FramerPluginContextType {
   isLoaded: boolean
   /** The function to show the UI interface. */
   showUI: (options: UIOptions) => Promise<void>
-  /** The function to set the UI options. */
-  setUIOptions: (options: UIOptions) => void
 }
 
 /**
@@ -48,8 +46,6 @@ export const FramerPluginProvider: React.FC<{
   const [id, setId] = useState<string>()
   const [name, setName] = useState<string>()
 
-  const uiOptions = useRef<UIOptions>({})
-
   useEffect(() => {
     (async () => {
       const config = await fetch('/framer.json').then(res => res.json())
@@ -64,17 +60,12 @@ export const FramerPluginProvider: React.FC<{
   const showUI = async (options?: UIOptions) => {
     await framer.showUI({
       title: name,
-      ...uiOptions.current,
       ...options,
     })
   }
 
-  const setUIOptions = (options: UIOptions) => {
-    uiOptions.current = options
-  }
-
   return (
-    <FramerPluginContext.Provider value={{ id: id!, name: name!, isLoaded, showUI, setUIOptions }}>
+    <FramerPluginContext.Provider value={{ id: id!, name: name!, isLoaded, showUI }}>
       {isLoaded && children}
     </FramerPluginContext.Provider>
   )

--- a/packages/toolbox/src/providers/framer-plugin.tsx
+++ b/packages/toolbox/src/providers/framer-plugin.tsx
@@ -1,5 +1,5 @@
 import { type UIOptions, framer } from 'framer-plugin'
-import { createContext, useEffect, useRef, useState } from 'react'
+import { createContext, useEffect, useState } from 'react'
 
 /**
  * The options of the UI interface.

--- a/plugins/basic/src/App.tsx
+++ b/plugins/basic/src/App.tsx
@@ -54,7 +54,6 @@ export function App() {
         minHeight: 300,
         minWidth: 500,
       }}
-      showOnMounted={false}
     >
       <SegmentedControls
         title="Auto Resize"


### PR DESCRIPTION
The `showOnMounted` property did not have any effect due to an `useEffect` hook within the auto-resizer.