### PR TITLE
Bump framer-plugin peer deps version

### DIFF
--- a/.changeset/brave-countries-smile.md
+++ b/.changeset/brave-countries-smile.md
@@ -1,0 +1,5 @@
+---
+"@triozer/framer-toolbox": minor
+---
+
+Bump framer-plugin peer dependency version

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -30,7 +30,7 @@
     "generate:docs": "pnpm generate:docs:api && pnpm generate:docs:json"
   },
   "peerDependencies": {
-    "framer-plugin": "^1",
+    "framer-plugin": "^2",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
   packages/toolbox:
     dependencies:
       framer-plugin:
-        specifier: ^1
-        version: 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^2
+        version: 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -2038,12 +2038,6 @@ packages:
         optional: true
       react-dom:
         optional: true
-
-  framer-plugin@1.0.0:
-    resolution: {integrity: sha512-N6C5NPA4BjGkPRhzIFKYMIH/wVkoekDO/jmuJQwauFGkPoIHfwo4ebn9sqgZkDx71xin/pOOqkpyhbxAoqX+0Q==}
-    peerDependencies:
-      react: ^18.2.0
-      react-dom: ^18.2.0
 
   framer-plugin@2.0.2:
     resolution: {integrity: sha512-Sm/7D1SisMp5JfDFb4Tb9omgbsqxNFNrOAMgJj6beIFAEPW7saSgc2sAWM00g1J/jdolOPVtD61S6z3EgqJFDg==}
@@ -5338,11 +5332,6 @@ snapshots:
     dependencies:
       tslib: 2.7.0
     optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  framer-plugin@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 


### PR DESCRIPTION
Update `framer-plugin` peer dependency version inside `framer-toolbox`. This will require to update to `framer-plugin@2` but it's fine as the major should not break anything.